### PR TITLE
Add 'use server' in `createTask`

### DIFF
--- a/templates/agent/src/app/actions/createTask.ts
+++ b/templates/agent/src/app/actions/createTask.ts
@@ -1,3 +1,5 @@
+'use server'
+
 import db from '~/utils/db'
 
 // Create a new task


### PR DESCRIPTION
This marks `app/actions/createTask.ts`  as a server action, which it seems to be missing among its 3 other peers.