### PR TITLE
Link to page.tsx file in VSCode

### DIFF
--- a/.changeset/many-cheetahs-approve.md
+++ b/.changeset/many-cheetahs-approve.md
@@ -1,0 +1,5 @@
+---
+"create-rubric-app": patch
+---
+
+Link to page.tsx file in VSCode

--- a/templates/blank/src/app/page.tsx
+++ b/templates/blank/src/app/page.tsx
@@ -1,13 +1,23 @@
 'use server'
 
+import Link from 'next/link'
+import {getDir} from '~/lib/utils'
 import DemoForm from '~/ui/home/demo-form'
 
 export default async function Page() {
+	const dir = getDir()
+
 	return (
 		<div className='flex h-screen w-full flex-col justify-center gap-10 p-5 sm:p-20'>
 			<h1>Welcome</h1>
 			<p>
-				To get started, edit <code>src/app/page.tsx</code> and save to reload.
+				To get started, edit{' '}
+				<Link
+					href={`vscode://file/${dir}/src/app/page.tsx`}
+					target='_blank'>
+					<code>src/app/page.tsx</code>
+				</Link>{' '}
+				and save to reload.
 			</p>
 			<DemoForm />
 		</div>

--- a/templates/blank/src/app/page.tsx
+++ b/templates/blank/src/app/page.tsx
@@ -13,7 +13,7 @@ export default async function Page() {
 			<p>
 				To get started, edit{' '}
 				<Link
-					href={`vscode://file/${dir}/src/app/page.tsx`}
+					href={`vscode://file${dir}/src/app/page.tsx`}
 					target='_blank'>
 					<code>src/app/page.tsx</code>
 				</Link>{' '}

--- a/templates/blank/src/lib/utils/index.ts
+++ b/templates/blank/src/lib/utils/index.ts
@@ -1,0 +1,6 @@
+export const getDir = () => {
+	const parts = __dirname.split('/')
+	const path = parts.slice(0, parts.indexOf('src') - 2).join('/')
+
+	return path
+}


### PR DESCRIPTION
- Links `page.tsx` directly to file in VSCode, by relative path

<img width="1041" alt="image" src="https://github.com/RubricLab/create-rubric-app/assets/36117635/987ae17b-b599-4c5c-9025-b7a6f31f9f52">
<img width="1501" alt="image" src="https://github.com/RubricLab/create-rubric-app/assets/36117635/6576cd47-c0e5-41af-a713-e4253042745e">
